### PR TITLE
remove comments page from dashboard

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -178,6 +178,8 @@ body {
 	}
 }
 
+// Login page styles
+
 body.logged_out {
 	h2 {
 		background-image: none;
@@ -197,4 +199,11 @@ body input[type=submit] {
 body input[type=submit]:hover {
 	background-image: none;
 	background-color: $menyoo-blue;
+}
+
+
+// login 'success' flash message
+
+body.flash {
+	background-image: none;
 }

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -130,7 +130,7 @@ ActiveAdmin.setup do |config|
   # This allows your users to comment on any resource registered with Active Admin.
   #
   # You can completely disable comments:
-  # config.comments = false
+  config.comments = false
   #
   # You can change the name under which comments are registered:
   # config.comments_registration_name = 'AdminComment'
@@ -323,7 +323,7 @@ ActiveAdmin.setup do |config|
   # By default, the footer shows the current Active Admin version. You can
   # override the content of the footer here.
   #
-  # config.footer = 'my custom footer text'
+  config.footer = 'Powered by Menyoo'
 
   # == Sorting
   #


### PR DESCRIPTION
Removed the default Active Admin comments page (can be reactivated later if needed)